### PR TITLE
Fix para conexão com o banco morta

### DIFF
--- a/lib/event_store/notifications/heartbeat.ex
+++ b/lib/event_store/notifications/heartbeat.ex
@@ -1,0 +1,49 @@
+defmodule EventStore.Notifications.Heartbeat do
+  @moduledoc """
+  This module contains a timeout mechanism to restart the Notifications database connection
+  and catch up the subscriptions to recent events periodically.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @timeout 10_000
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(state) do
+    schedule_work()
+    {:ok, state}
+  end
+
+  def handle_info(:heartbeat, state) do
+    Logger.debug("Killing Postgrex Notifications due to listener heartbeat")
+    restart_notifications()
+
+    Logger.debug("Catching up subscriptions due to listener heartbeat")
+    catch_up_subscriptions()
+
+    schedule_work()
+    {:noreply, state}
+  end
+
+  defp schedule_work(), do: Process.send_after(self(), :heartbeat, @timeout)
+
+  defp restart_notifications() do
+    EventStore.Notifications.Listener.Postgrex
+    |> :sys.get_state()
+    |> Map.get(:pid)
+    |> Process.exit(:kill)
+  end
+
+  defp catch_up_subscriptions() do
+    EventStore.Subscriptions.Supervisor
+    |> Supervisor.which_children()
+    |> Enum.each(fn {_, subscription, _, _} ->
+      EventStore.Subscriptions.Subscription.catch_up(subscription)
+    end)
+  end
+end

--- a/lib/event_store/notifications/listener.ex
+++ b/lib/event_store/notifications/listener.ex
@@ -11,7 +11,7 @@ defmodule EventStore.Notifications.Listener do
 
   require Logger
 
-  alias EventStore.Notifications.Listener
+  alias EventStore.Notifications.{Listener, PostgrexNotifications}
 
   defstruct demand: 0,
             queue: :queue.new(),
@@ -85,7 +85,7 @@ defmodule EventStore.Notifications.Listener do
 
   defp listen_for_events(%Listener{} = state) do
     {:ok, ref} =
-      Postgrex.Notifications.listen(EventStore.Notifications.Listener.Postgrex, "events")
+      PostgrexNotifications.listen(EventStore.Notifications.Listener.Postgrex, "events")
 
     %Listener{state | ref: ref}
   end

--- a/lib/event_store/notifications/postgrex_notifications.ex
+++ b/lib/event_store/notifications/postgrex_notifications.ex
@@ -12,8 +12,9 @@ defmodule EventStore.Notifications.PostgrexNotifications do
   alias Postgrex.Protocol
 
   @timeout 5000
+  @idle_timeout 5000
 
-  defstruct idle_timeout: 5000,
+  defstruct idle_timeout: @idle_timeout,
             protocol: nil,
             parameters: nil,
             listeners: Map.new(),
@@ -106,7 +107,7 @@ defmodule EventStore.Notifications.PostgrexNotifications do
   def connect(_, opts) do
     case Protocol.connect([types: nil] ++ opts) do
       {:ok, protocol} ->
-        idle_timeout = Keyword.get(opts, :idle_timeout, 5000)
+        idle_timeout = Keyword.get(opts, :idle_timeout, @idle_timeout)
         {:ok, %__MODULE__{idle_timeout: idle_timeout, protocol: protocol}, idle_timeout}
 
       {:error, reason} ->

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -14,6 +14,7 @@ defmodule EventStore.Notifications.Supervisor do
   alias EventStore.{Config, MonitoredServer}
 
   alias EventStore.Notifications.{
+    Heartbeat,
     Listener,
     PostgrexNotifications,
     Reader,
@@ -67,7 +68,8 @@ defmodule EventStore.Notifications.Supervisor do
         ),
         {Listener, []},
         {Reader, Config.serializer()},
-        {StreamBroadcaster, []}
+        {StreamBroadcaster, []},
+        {Heartbeat, []}
       ],
       strategy: :one_for_all
     )

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -58,6 +58,16 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   @doc """
+  Catch up the subscription with recent events.
+
+  Used to catch any missing events that may have happened while a database
+  connection was down.
+  """
+  def catch_up(subscription) do
+    GenServer.cast(subscription, :catch_up)
+  end
+
+  @doc """
   Attempt to reconnect the subscription.
 
   Typically used to resume a subscription after a database connection failure.


### PR DESCRIPTION
## Descrição do Bug
<!-- Como esse bug pode ser reproduzido? -->
Depois de X tempo a conexão da eventstore que escuta eventos com o banco morre silenciosamente.
Isso não é detectado e os event handlers/process managers param de escutar os novos eventos produzidos.

## Contexto do funcionamento simplificado da EventStore
#### Produção de eventos:
- Eventos são inseridos no banco na tabela "events"

#### Conexão entre produção de eventos e subscribers (quem escuta evento)
- Trigger na tabela "events" dispara um NOTIFY
- Um processo (PostgrexNotifications) dá o LISTEN e aguarda os NOTIFY com os eventos novos.
- Esse processo envia os eventos para as subscriptions (event handlers e process managers).

## Comportamento esperado
<!-- Descrição do comportamento esperado -->
1) A conexão morta é detectada e reiniciada.
2) Novos eventos são escutados a partir desse momento.
3) Eventos produzidos enquanto a conexão estava morta são processados pelos interessados.

## Reproduzindo o bug
Não foi possível reproduzir o bug exatamente como acontece em produção. Alguns approaches tentados:
- Deletar descriptor file da conexão TCP com o banco
- Usar dois proxies TCP entre a aplicação e o banco e matar o mais próximo ao banco.
- Matar #Port da conexão com o banco pelo Elixir

Em nenhum dos casos foi possível fazer a conexão se manter morta como acontece em produção. Sua morte era detectada e a conexão era reiniciada em todos os casos. O que foi possível fazer:
- Desligar o mecanismo de detecção de conexão morta atual para simular esse cenário.

## Solução
A solução foi ativamente reiniciar a conexão em um timeout específico (5s). E ela envolve duas ações.
1) Matar o processo PostgrexNotifications que se conecta ao banco e executa o LISTEN.
2) Fazer com que todas as subscriptions (processos interessados em ouvir eventos) escutem os eventos que ainda não escutaram.

## Observações
1) Já existe um approach mais soft do que matar o processo atualmente. Que é executar um ping no banco, mas aparentemente isso não foi suficiente pra detectar as conexões mortas. Foi tentado o approach de dar um UNLISTEN + LISTEN em seguida e também não foi efetivo.
2) A solução 2. talvez não seja necessária. Esses eventos que são produzidos enquanto a conexão estava morta só não são escutados até que um novo evento seja produzido. Assim que um novo evento é produzido, todos os anteriores são escutados. Pra gente pode ser mais essencial nesse início porque temos um volume baixo de transações, mas no futuro pode ser desnecessário.

## Chute random sobre causa do bug
Os proxies entre a nossa aplicação e o Postgres na GCP podem perder a conexão com o banco e não detectam isso. Com isso nossa aplicação acha que está conectada porque a conexão com o proxy está ok, mas o proxy com o banco perde a conexão e não detecta isso.

@robsonpeixoto depois dá um feedback sobre essa possibilidade.
