### PR TITLE
Pooling nas subscriptions

### DIFF
--- a/config/distributed.exs
+++ b/config/distributed.exs
@@ -19,4 +19,5 @@ config :eventstore, EventStore.Storage,
 config :eventstore,
   registry: :distributed,
   restart_stream_timeout: 1_000,
-  subscription_retry_interval: 1_000
+  subscription_retry_interval: 1_000,
+  event_pooling_interval: 1_000

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -19,4 +19,5 @@ config :eventstore, EventStore.Storage,
 config :eventstore,
   column_data_type: "jsonb",
   registry: :local,
-  subscription_retry_interval: 1_000
+  subscription_retry_interval: 1_000,
+  event_pooling_interval: 1_000

--- a/config/local.exs
+++ b/config/local.exs
@@ -17,4 +17,5 @@ config :eventstore, EventStore.Storage,
 
 config :eventstore,
   registry: :local,
-  subscription_retry_interval: 1_000
+  subscription_retry_interval: 1_000,
+  event_pooling_interval: 1_000

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,4 +17,5 @@ config :eventstore, EventStore.Storage,
 
 config :eventstore,
   registry: :local,
-  subscription_retry_interval: 1_000
+  subscription_retry_interval: 1_000,
+  event_pooling_interval: 1_000

--- a/lib/event_store/notifications/listener.ex
+++ b/lib/event_store/notifications/listener.ex
@@ -12,7 +12,7 @@ defmodule EventStore.Notifications.Listener do
   require Logger
 
   alias EventStore.MonitoredServer
-  alias EventStore.Notifications.Listener
+  alias EventStore.Notifications.{Listener, PostgrexNotifications}
 
   defstruct demand: 0,
             queue: :queue.new(),
@@ -76,7 +76,7 @@ defmodule EventStore.Notifications.Listener do
 
   defp listen_for_events(%Listener{} = state) do
     {:ok, ref} =
-      Postgrex.Notifications.listen(EventStore.Notifications.Listener.Postgrex, "events")
+      PostgrexNotifications.listen(EventStore.Notifications.Listener.Postgrex, "events")
 
     %Listener{state | ref: ref}
   end

--- a/test/notifications/notify_events_test.exs
+++ b/test/notifications/notify_events_test.exs
@@ -2,6 +2,7 @@ defmodule EventStore.Notifications.NotifyEventsTest do
   use EventStore.StorageCase
 
   alias EventStore.{Config, EventFactory, ProcessHelper}
+  alias EventStore.Notifications.PostgrexNotifications
 
   @channel "events"
 
@@ -11,8 +12,8 @@ defmodule EventStore.Notifications.NotifyEventsTest do
       |> Config.sync_connect_postgrex_opts()
       |> Keyword.put(:name, __MODULE__)
 
-    {:ok, conn} = Postgrex.Notifications.start_link(listener_opts)
-    {:ok, ref} = Postgrex.Notifications.listen(conn, @channel)
+    {:ok, conn} = PostgrexNotifications.start_link(listener_opts)
+    {:ok, ref} = PostgrexNotifications.listen(conn, @channel)
 
     on_exit(fn ->
       ProcessHelper.shutdown(conn)


### PR DESCRIPTION
## Descrição


## Contexto do funcionamento simplificado da EventStore
#### Produção de eventos:
- Eventos são inseridos no banco na tabela "events"

#### Conexão entre produção de eventos e subscribers (quem escuta evento)
- Trigger na tabela "events" dispara um NOTIFY
- Um processo (PostgrexNotifications) dá o LISTEN e aguarda os NOTIFY com os eventos novos.
- Esse processo envia os eventos para as subscriptions (event handlers e process managers).

## Comportamento esperado
<!-- Descrição do comportamento esperado -->
1) A conexão morta é detectada e reiniciada.
2) Novos eventos são escutados a partir desse momento.
3) Eventos produzidos enquanto a conexão estava morta são processados pelos interessados.

## Reproduzindo o bug
Não foi possível reproduzir o bug exatamente como acontece em produção. Alguns approaches tentados:
- Deletar descriptor file da conexão TCP com o banco
- Usar dois proxies TCP entre a aplicação e o banco e matar o mais próximo ao banco.
- Matar #Port da conexão com o banco pelo Elixir

Em nenhum dos casos foi possível fazer a conexão se manter morta como acontece em produção. Sua morte era detectada e a conexão era reiniciada em todos os casos. O que foi possível fazer:
- Desligar o mecanismo de detecção de conexão morta atual para simular esse cenário.

## Solução anterior
A solução anterior envolvia criar um processo que a cada 5s dava um disconnect/reconnect no Listener e  buscava as subscriptions (processos interessados em ouvir eventos) e fazia com que todas ouvissem os eventos que ainda não escutaram (catch up).

O disconnect/reconnect no Listener não foi o suficiente para que os NOTIFY do Postgrex funcionassem, mas o catch up das subscriptions funcionou.

## Solução atual
Essa solução é uma melhoria da anterior em que a lógica de fazer o pooling dos eventos não fica num processo separado mas dentro de cada subscription.